### PR TITLE
Revert back, id param not needed

### DIFF
--- a/src/ng-couchbase-lite.js
+++ b/src/ng-couchbase-lite.js
@@ -103,7 +103,7 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
          * @param    object jsonDocument
          * @return   promise
          */
-        createDocument: function(jsonDocument,id) { 
+        createDocument: function(jsonDocument) { 
             return this.makeRequest("POST", this.databaseUrl + this.databaseName, {}, jsonDocument);
         },
         

--- a/src/ng-couchbase-lite.js
+++ b/src/ng-couchbase-lite.js
@@ -103,7 +103,10 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
          * @param    string id , object jsonDocument
          * @return   promise
          */
-        createDocument: function(id,jsonDocument) {
+        createDocument: function(jsonDocument,id) {
+            if(!id){
+            	id = "";
+            }
             return this.makeRequest("POST", this.databaseUrl + this.databaseName + "/" + id, {}, jsonDocument);
         },
         

--- a/src/ng-couchbase-lite.js
+++ b/src/ng-couchbase-lite.js
@@ -100,7 +100,7 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
         /*
          * Create a new database document
          *
-         * @param    string id , object jsonDocument
+         * @param    object jsonDocument, string id (optional)
          * @return   promise
          */
         createDocument: function(jsonDocument,id) {

--- a/src/ng-couchbase-lite.js
+++ b/src/ng-couchbase-lite.js
@@ -100,14 +100,11 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
         /*
          * Create a new database document
          *
-         * @param    object jsonDocument, string id (optional)
+         * @param    object jsonDocument
          * @return   promise
          */
-        createDocument: function(jsonDocument,id) {
-            if(!id){
-            	id = "";
-            }
-            return this.makeRequest("POST", this.databaseUrl + this.databaseName + "/" + id, {}, jsonDocument);
+        createDocument: function(jsonDocument,id) { 
+            return this.makeRequest("POST", this.databaseUrl + this.databaseName, {}, jsonDocument);
         },
         
         /*


### PR DESCRIPTION
You can either specify the document ID by including the _id object in the request message body, or let the software generate an ID.
