### PR TITLE
makeRequest to return $http(settings) instead if creating new promise

### DIFF
--- a/src/ng-couchbase-lite.js
+++ b/src/ng-couchbase-lite.js
@@ -234,7 +234,31 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
                 settings.data = data;
             }
             return $http(settings);
-        }
+        },
+
+	/*
+         * Make a RESTful request to an endpoint while providing parameters or data or both
+         *
+         * @param    string method
+         * @param    string url
+         * @param    object params
+         * @param    object data
+         * @return   promise with all of return data (data, status, headers, config)
+         */
+	makeCompleteRequest: function(method, url, params, data) { 
+		var settings = {
+			method: method,
+			url: url,
+			withCredentials: true
+		};
+		if(params) {
+			settings.params = params;
+		}
+		if(data) {
+			settings.data = data;
+		}
+		return $http(settings) 
+	}
 
     };
 

--- a/src/ng-couchbase-lite.js
+++ b/src/ng-couchbase-lite.js
@@ -221,7 +221,7 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
          * @param    object data
 	 * @param    boolean complete 
          * @return   promise
-        */
+         */
 	makeRequest: function(method, url, params, data,complete) {
 		var deferred = $q.defer();
 		var settings = {

--- a/src/ng-couchbase-lite.js
+++ b/src/ng-couchbase-lite.js
@@ -212,30 +212,6 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
 		return this.makeRequest("GET", this.databaseUrl + "_active_tasks");
 	},
 
-        /*
-         * Make a RESTful request to an endpoint while providing parameters or data or both
-         *
-         * @param    string method
-         * @param    string url
-         * @param    object params
-         * @param    object data
-         * @return   promise
-         */
-        makeRequest: function(method, url, params, data) { 
-            var settings = {
-                method: method,
-                url: url,
-                withCredentials: true
-            };
-            if(params) {
-                settings.params = params;
-            }
-            if(data) {
-                settings.data = data;
-            }
-            return $http(settings);
-        },
-
 	/*
          * Make a RESTful request to an endpoint while providing parameters or data or both
          *
@@ -243,9 +219,11 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
          * @param    string url
          * @param    object params
          * @param    object data
-         * @return   promise with all of return data (data, status, headers, config)
-         */
-	makeCompleteRequest: function(method, url, params, data) { 
+	 * @param    boolean complete 
+         * @return   promise
+        */
+	makeRequest: function(method, url, params, data,complete) {
+		var deferred = $q.defer();
 		var settings = {
 			method: method,
 			url: url,
@@ -257,7 +235,18 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
 		if(data) {
 			settings.data = data;
 		}
-		return $http(settings) 
+		if(complete){
+			return $http(settings);
+		}
+		$http(settings)
+			.success(function(result) {
+			deferred.resolve(result);
+		})
+			.error(function(error) {
+			deferred.reject(error);
+		});
+
+		return deferred.promise;
 	}
 
     };

--- a/src/ng-couchbase-lite.js
+++ b/src/ng-couchbase-lite.js
@@ -221,8 +221,7 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
          * @param    object data
          * @return   promise
          */
-        makeRequest: function(method, url, params, data) {
-            var deferred = $q.defer();
+        makeRequest: function(method, url, params, data) { 
             var settings = {
                 method: method,
                 url: url,
@@ -234,14 +233,7 @@ angular.module("ngCouchbaseLite", []).factory("$couchbase", ["$q", "$http", "$ro
             if(data) {
                 settings.data = data;
             }
-            $http(settings)
-                .success(function(result) {
-                    deferred.resolve(result);
-                })
-                .error(function(error) {
-                    deferred.reject(error);
-                });
-            return deferred.promise;
+            return $http(settings);
         }
 
     };


### PR DESCRIPTION
Since $http(settings) is already a promise, there is no need to create a new promise. 

Just doing `return $http(settings)` will give you all the params because the response has 4 params (data, status, headers, config) and the error has 2 (data, status).

This way your not just resolving or rejecting the data param, but all of them are passed on.  
